### PR TITLE
Add cancellation token parameter to all async methods

### DIFF
--- a/Omg.Lol.Net.Tests/IntegrationTests/OmgClientBuilderTests.cs
+++ b/Omg.Lol.Net.Tests/IntegrationTests/OmgClientBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Omg.Lol.Net.Tests.IntegrationTests;
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
@@ -162,5 +163,5 @@ internal class TestApiKeyProvider : IApiKeyProvider
     public readonly string Token = Guid.NewGuid().ToString();
 #pragma warning restore SA1401
 
-    public Task<string> GetApiKeyAsync() => Task.FromResult(this.Token);
+    public Task<string> GetApiKeyAsync(CancellationToken cancellationToken = default) => Task.FromResult(this.Token);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IAccountClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IAccountClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -8,19 +9,19 @@ using Omg.Lol.Net.Models.Items;
 
 public interface IAccountClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<AccountInformation>> RetrieveAccountInformationAsync(string email);
+    public Task<CommonResponse<AccountInformation>> RetrieveAccountInformationAsync(string email, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AccountAddress[]>> RetrieveAccountAddressesAsync(string email);
+    public Task<CommonResponse<AccountAddress[]>> RetrieveAccountAddressesAsync(string email, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AccountName>> RetrieveAccountNameAsync(string email);
+    public Task<CommonResponse<AccountName>> RetrieveAccountNameAsync(string email, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AccountSettings>> RetrieveAccountSettingsAsync(string email);
+    public Task<CommonResponse<AccountSettings>> RetrieveAccountSettingsAsync(string email, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> SetAccountSettingsAsync(string email, AccountSettings settings);
+    public Task<CommonResponse<MessageItem>> SetAccountSettingsAsync(string email, AccountSettings settings, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AccountName>> SetAccountNameAsync(string email, string newName);
+    public Task<CommonResponse<AccountName>> SetAccountNameAsync(string email, string newName, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AccountSession[]>> RetrieveAccountSessionsAsync(string email);
+    public Task<CommonResponse<AccountSession[]>> RetrieveAccountSessionsAsync(string email, CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> DeleteAccountSessionAsync(string email, string sessionId);
+    public Task<CommonResponse<MessageItem>> DeleteAccountSessionAsync(string email, string sessionId, CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IAddressClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IAddressClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -7,11 +8,19 @@ using Omg.Lol.Net.Models.Address;
 
 public interface IAddressClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<AddressAvailability>> RetrieveAddressAvailabilityAsync(string address);
+    public Task<CommonResponse<AddressAvailability>> RetrieveAddressAvailabilityAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<AddressExpirationPublicView>> RetrieveAddressExpirationAsync(string address);
+    public Task<CommonResponse<AddressExpirationPublicView>> RetrieveAddressExpirationAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<PublicAddressInformation>> RetrievePublicAddressInformationAsync(string address);
+    public Task<CommonResponse<PublicAddressInformation>> RetrievePublicAddressInformationAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<PrivateAddressInformation>> RetrievePrivateAddressInformationAsync(string address);
+    public Task<CommonResponse<PrivateAddressInformation>> RetrievePrivateAddressInformationAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IDnsClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IDnsClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -8,9 +9,14 @@ using Omg.Lol.Net.Models.Items;
 
 public interface IDnsClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<MultipleDnsRecords>> RetrieveDnsRecordsAsync(string address);
+    public Task<CommonResponse<MultipleDnsRecords>> RetrieveDnsRecordsAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<DnsModified>> CreateDnsRecordAsync(string address, DnsRecordPost record);
+    public Task<CommonResponse<DnsModified>> CreateDnsRecordAsync(
+        string address,
+        DnsRecordPost record,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update an existing DNS record. Note the update performs a replacement of the whole data structure.
@@ -18,7 +24,13 @@ public interface IDnsClient : IApiInfoCarrier
     /// <param name="address">The address the DNS record belongs to.</param>
     /// <param name="record">The content to update. This will completely replace the existing record.</param>
     /// <returns></returns>
-    public Task<CommonResponse<DnsModified>> UpdateDnsRecordAsync(string address, DnsRecordUpdate record);
+    public Task<CommonResponse<DnsModified>> UpdateDnsRecordAsync(
+        string address,
+        DnsRecordUpdate record,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> DeleteDnsRecordAsync(string address, string recordId);
+    public Task<CommonResponse<MessageItem>> DeleteDnsRecordAsync(
+        string address,
+        string recordId,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IPastebinClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IPastebinClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -8,13 +9,26 @@ using Omg.Lol.Net.Models.Paste;
 
 public interface IPastebinClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<SinglePaste>> RetrieveASpecificPasteAsync(string address, string pasteTitle);
+    public Task<CommonResponse<SinglePaste>> RetrieveASpecificPasteAsync(
+        string address,
+        string pasteTitle,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MultiplePastes>> RetrievePublicAndPrivatePastebinAsync(string address);
+    public Task<CommonResponse<MultiplePastes>> RetrievePublicAndPrivatePastebinAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MultiplePastes>> RetrievePublicPastebinAsync(string address);
+    public Task<CommonResponse<MultiplePastes>> RetrievePublicPastebinAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<PasteModified>> CreateOrUpdatePasteAsync(string address, PastePost paste);
+    public Task<CommonResponse<PasteModified>> CreateOrUpdatePasteAsync(
+        string address,
+        PastePost paste,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> DeletePasteAsync(string address, string pasteTitle);
+    public Task<CommonResponse<MessageItem>> DeletePasteAsync(
+        string address,
+        string pasteTitle,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IPurlsClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IPurlsClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -8,12 +9,23 @@ using Omg.Lol.Net.Models.Purl;
 
 public interface IPurlsClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<SinglePurl>> RetrievePurlAsync(string address, string purlName);
+    public Task<CommonResponse<SinglePurl>> RetrievePurlAsync(
+        string address,
+        string purlName,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> DeletePurlAsync(string address, string purlName);
+    public Task<CommonResponse<MessageItem>> DeletePurlAsync(
+        string address,
+        string purlName,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MultiplePurls>> RetrievePurlsAsync(string address);
+    public Task<CommonResponse<MultiplePurls>> RetrievePurlsAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
     // todo: this return value doesn't follow the API, to save an extra model.
-    public Task<CommonResponse<MessageItem>> CreatePurlAsync(string address, PurlPost purl);
+    public Task<CommonResponse<MessageItem>> CreatePurlAsync(
+        string address,
+        PurlPost purl,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IServiceClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IServiceClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -7,5 +8,5 @@ using Omg.Lol.Net.Models.ServiceStatus;
 
 public interface IServiceClient : IApiInfoCarrier
 {
-    public Task<CommonResponse<ServiceInfo>> GetServiceStatistics();
+    public Task<CommonResponse<ServiceInfo>> GetServiceStatistics(CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Abstract/IStatuslogClient.cs
+++ b/Omg.Lol.Net/Clients/Abstract/IStatuslogClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Abstract;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Infrastructure;
 using Omg.Lol.Net.Models;
@@ -14,7 +15,10 @@ public interface IStatuslogClient : IApiInfoCarrier
     /// <param name="address">The address the status belongs to.</param>
     /// <param name="statusId">The status id.</param>
     /// <returns>A single status.</returns>
-    public Task<CommonResponse<SingleStatus>> RetrieveInvidualStatusAsync(string address, string statusId);
+    public Task<CommonResponse<SingleStatus>> RetrieveInvidualStatusAsync(
+        string address,
+        string statusId,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete a status belonging to a given account with a status id.
@@ -23,7 +27,10 @@ public interface IStatuslogClient : IApiInfoCarrier
     /// <param name="statusId">The status id.</param>
     /// <returns>A message confirming the deletion.</returns>
     // Todo: undocumented API
-    public Task<CommonResponse<MessageItem>> DeleteStatusAsync(string address, string statusId);
+    public Task<CommonResponse<MessageItem>> DeleteStatusAsync(
+        string address,
+        string statusId,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieve the latest status of a given account.
@@ -31,33 +38,50 @@ public interface IStatuslogClient : IApiInfoCarrier
     /// <param name="address">The address.</param>
     /// <returns>The lastest (single) status.</returns>
     // todo: Undocumented api
-    public Task<CommonResponse<SingleStatus>> RetrieveLatestStatusAsync(string address);
+    public Task<CommonResponse<SingleStatus>> RetrieveLatestStatusAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieve all statuses belonging to an address.
     /// </summary>
     /// <param name="address">The address.</param>
     /// <returns>All statuses this address posted.</returns>
-    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(string address);
+    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieve all statuses in omg.lol service.
     /// </summary>
     /// <returns>All statuses in the omg.lol service.</returns>
-    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync();
+    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieve statuses in omg.lol service in the past two days.
     /// </summary>
     /// <returns>All statuses in the omg.lol service in the past two days.</returns>
-    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireLatestStatusAsync();
+    public Task<CommonResponse<MultipleStatuses>> RetrieveEntireLatestStatusAsync(
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<StatusModified>> CreateStatusAsync(string address, StatusPost status);
+    public Task<CommonResponse<StatusModified>> CreateStatusAsync(
+        string address,
+        StatusPost status,
+        CancellationToken cancellationToken = default);
 
     // Todo: inconsistency in doc and postman collection.
-    public Task<CommonResponse<StatusModified>> UpdateStatusAsync(string address, StatusPatch status);
+    public Task<CommonResponse<StatusModified>> UpdateStatusAsync(
+        string address,
+        StatusPatch status,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<StatusBio>> RetrieveStatusBioAsync(string address);
+    public Task<CommonResponse<StatusBio>> RetrieveStatusBioAsync(
+        string address,
+        CancellationToken cancellationToken = default);
 
-    public Task<CommonResponse<MessageItem>> UpdateStatusBioAsync(string address, ContentItem content);
+    public Task<CommonResponse<MessageItem>> UpdateStatusBioAsync(
+        string address,
+        ContentItem content,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Clients/Implementation/AccountClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/AccountClient.cs
@@ -1,6 +1,7 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Omg.Lol.Net.Clients.Abstract;
@@ -38,56 +39,77 @@ public sealed class AccountClient : IAccountClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<AccountInformation>> RetrieveAccountInformationAsync(string email)
+    public async Task<CommonResponse<AccountInformation>> RetrieveAccountInformationAsync(
+        string email,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AccountInformation>>(
-                this.Url + string.Format(RetrieveAccountInformationEndpoint, email), this.Token)
+                this.Url + string.Format(RetrieveAccountInformationEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<AccountAddress[]>> RetrieveAccountAddressesAsync(string email)
+    public async Task<CommonResponse<AccountAddress[]>> RetrieveAccountAddressesAsync(
+        string email,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AccountAddress[]>>(
-                this.Url + string.Format(RetrieveAccountAddressesEndpoint, email), this.Token)
+                this.Url + string.Format(RetrieveAccountAddressesEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<AccountName>> RetrieveAccountNameAsync(string email)
+    public async Task<CommonResponse<AccountName>> RetrieveAccountNameAsync(
+        string email,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AccountName>>(
-                this.Url + string.Format(RetrieveAccountNameEndpoint, email), this.Token)
+                this.Url + string.Format(RetrieveAccountNameEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<AccountSettings>> RetrieveAccountSettingsAsync(string email)
+    public async Task<CommonResponse<AccountSettings>> RetrieveAccountSettingsAsync(
+        string email,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AccountSettings>>(
-                this.Url + string.Format(RetrieveAccountSettingsEndpoint, email), this.Token)
+                this.Url + string.Format(RetrieveAccountSettingsEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 
     // Skip test due to test concurrency issue
     [ExcludeFromCodeCoverage]
-    public async Task<CommonResponse<MessageItem>> SetAccountSettingsAsync(string email, AccountSettings settings)
+    public async Task<CommonResponse<MessageItem>> SetAccountSettingsAsync(
+        string email,
+        AccountSettings settings,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PutAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(SetAccountsettingsEndpoint, email),
                 JsonConvert.SerializeObject(settings),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
     // Skip test due to test concurrency issue
     [ExcludeFromCodeCoverage]
-    public async Task<CommonResponse<AccountName>> SetAccountNameAsync(string email, string newName)
+    public async Task<CommonResponse<AccountName>> SetAccountNameAsync(
+        string email,
+        string newName,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PutAsync<CommonResponse<AccountName>>(
                 this.Url + string.Format(SetAccountNameEndpoint, email),
                 JsonConvert.SerializeObject(new
                 {
                     name = newName,
                 }),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<AccountSession[]>> RetrieveAccountSessionsAsync(string email)
+    public async Task<CommonResponse<AccountSession[]>> RetrieveAccountSessionsAsync(
+        string email,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AccountSession[]>>(
-                this.Url + string.Format(RetrieveAccountSessionsEndpoint, email), this.Token)
+                this.Url + string.Format(RetrieveAccountSessionsEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 
     //Skip test because we don't automatic way to create sessions
     [ExcludeFromCodeCoverage]
-    public async Task<CommonResponse<MessageItem>> DeleteAccountSessionAsync(string email, string sessionId)
+    public async Task<CommonResponse<MessageItem>> DeleteAccountSessionAsync(
+        string email,
+        string sessionId,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.DeleteAsync<CommonResponse<MessageItem>>(
-                this.Url + string.Format(DeleteAccountSessionsEndpoint, email), this.Token)
+                this.Url + string.Format(DeleteAccountSessionsEndpoint, email), this.Token, cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/AddressClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/AddressClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Clients.Abstract;
 using Omg.Lol.Net.Infrastructure;
@@ -26,23 +27,31 @@ public sealed class AddressClient : IAddressClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<AddressAvailability>> RetrieveAddressAvailabilityAsync(string address)
+    public async Task<CommonResponse<AddressAvailability>> RetrieveAddressAvailabilityAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AddressAvailability>>(
-            this.Url + string.Format(RetreiveAddressAvailabilityEndpoint, address))
+                this.Url + string.Format(RetreiveAddressAvailabilityEndpoint, address), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<AddressExpirationPublicView>> RetrieveAddressExpirationAsync(string address)
+    public async Task<CommonResponse<AddressExpirationPublicView>> RetrieveAddressExpirationAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<AddressExpirationPublicView>>(
-            this.Url + string.Format(RetrieveAddressExpirationEndpoint, address))
+                this.Url + string.Format(RetrieveAddressExpirationEndpoint, address), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<PublicAddressInformation>> RetrievePublicAddressInformationAsync(string address)
+    public async Task<CommonResponse<PublicAddressInformation>> RetrievePublicAddressInformationAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<PublicAddressInformation>>(
-            this.Url + string.Format(RetrieveAddressInformationEndpoint, address))
+                this.Url + string.Format(RetrieveAddressInformationEndpoint, address), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<PrivateAddressInformation>> RetrievePrivateAddressInformationAsync(string address)
+    public async Task<CommonResponse<PrivateAddressInformation>> RetrievePrivateAddressInformationAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<PrivateAddressInformation>>(
-            this.Url + string.Format(RetrieveAddressInformationEndpoint, address), this.Token)
+                this.Url + string.Format(RetrieveAddressInformationEndpoint, address), this.Token, cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/DnsClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/DnsClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Omg.Lol.Net.Clients.Abstract;
@@ -29,30 +30,45 @@ public sealed class DnsClient : IDnsClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<MultipleDnsRecords>> RetrieveDnsRecordsAsync(string address)
+    public async Task<CommonResponse<MultipleDnsRecords>> RetrieveDnsRecordsAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<MultipleDnsRecords>>(
                 this.Url + string.Format(RetrieveDnsRecordsEndpoint, address),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<DnsModified>> CreateDnsRecordAsync(string address, DnsRecordPost record)
+    public async Task<CommonResponse<DnsModified>> CreateDnsRecordAsync(
+        string address,
+        DnsRecordPost record,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PostAsync<CommonResponse<DnsModified>>(
                 this.Url + string.Format(CreateaDnsRecordEndpoint, address),
                 JsonConvert.SerializeObject(record),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
     // TODO: Come back when this https://github.com/neatnik/omg.lol/issues/532 is resolved.
-    public async Task<CommonResponse<DnsModified>> UpdateDnsRecordAsync(string address, DnsRecordUpdate record)
+    public async Task<CommonResponse<DnsModified>> UpdateDnsRecordAsync(
+        string address,
+        DnsRecordUpdate record,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PutAsync<CommonResponse<DnsModified>>(
                 this.Url + string.Format(UpdateExistingDnsRecordEnpoint, address),
                 JsonConvert.SerializeObject(record),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> DeleteDnsRecordAsync(string address, string recordId)
+    public async Task<CommonResponse<MessageItem>> DeleteDnsRecordAsync(
+        string address,
+        string recordId,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.DeleteAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(DeleteDnsRecordEnpoint, address, recordId),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/PastebinClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/PastebinClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Omg.Lol.Net.Clients.Abstract;
@@ -29,36 +30,54 @@ public sealed class PastebinClient : IPastebinClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<SinglePaste>> RetrieveASpecificPasteAsync(string address, string pasteTitle)
+    public async Task<CommonResponse<SinglePaste>> RetrieveASpecificPasteAsync(
+        string address,
+        string pasteTitle,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
             .GetAsync<CommonResponse<SinglePaste>>(
-                this.Url + string.Format(RetrieveASpecificPasteEndpoint, address, pasteTitle))
+                this.Url + string.Format(RetrieveASpecificPasteEndpoint, address, pasteTitle), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultiplePastes>> RetrievePublicAndPrivatePastebinAsync(string address)
+    public async Task<CommonResponse<MultiplePastes>> RetrievePublicAndPrivatePastebinAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
             .GetAsync<CommonResponse<MultiplePastes>>(
                 this.Url + string.Format(RetrievePastebinEndpoint, address),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultiplePastes>> RetrievePublicPastebinAsync(string address)
+    public async Task<CommonResponse<MultiplePastes>> RetrievePublicPastebinAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
-            .GetAsync<CommonResponse<MultiplePastes>>(this.Url + string.Format(RetrievePastebinEndpoint, address))
+            .GetAsync<CommonResponse<MultiplePastes>>(
+                this.Url + string.Format(RetrievePastebinEndpoint, address),
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<PasteModified>> CreateOrUpdatePasteAsync(string address, PastePost paste)
+    public async Task<CommonResponse<PasteModified>> CreateOrUpdatePasteAsync(
+        string address,
+        PastePost paste,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
             .PostAsync<CommonResponse<PasteModified>>(
                 this.Url + string.Format(CreateOrUpdatePasteEndpoint, address),
                 JsonConvert.SerializeObject(paste),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> DeletePasteAsync(string address, string pasteTitle)
+    public async Task<CommonResponse<MessageItem>> DeletePasteAsync(
+        string address,
+        string pasteTitle,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
             .DeleteAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(DeletePasteEndpoint, address, pasteTitle),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/PurlsClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/PurlsClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Omg.Lol.Net.Clients.Abstract;
@@ -31,28 +32,43 @@ public sealed class PurlsClient : IPurlsClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<SinglePurl>> RetrievePurlAsync(string address, string purlName)
+    public async Task<CommonResponse<SinglePurl>> RetrievePurlAsync(
+        string address,
+        string purlName,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<SinglePurl>>(
                 this.Url + string.Format(RetrieveSpecificPurlEndpoint, address, purlName),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> DeletePurlAsync(string address, string purlName)
+    public async Task<CommonResponse<MessageItem>> DeletePurlAsync(
+        string address,
+        string purlName,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.DeleteAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(DeleteSpecificPurlEndpoint, address, purlName),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultiplePurls>> RetrievePurlsAsync(string address)
+    public async Task<CommonResponse<MultiplePurls>> RetrievePurlsAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<MultiplePurls>>(
                 this.Url + string.Format(RetrieveAllPurlEndpoint, address),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> CreatePurlAsync(string address, PurlPost purl)
+    public async Task<CommonResponse<MessageItem>> CreatePurlAsync(
+        string address,
+        PurlPost purl,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PutAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(CreateNewPurlEndpoint, address),
                 JsonConvert.SerializeObject(purl),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/ServiceClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/ServiceClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Omg.Lol.Net.Clients.Abstract;
 using Omg.Lol.Net.Infrastructure;
@@ -21,8 +22,8 @@ public sealed class ServiceClient : IServiceClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<ServiceInfo>> GetServiceStatistics()
+    public async Task<CommonResponse<ServiceInfo>> GetServiceStatistics(CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler
-            .GetAsync<CommonResponse<ServiceInfo>>(this.Url + RetrieveServiceInformation)
+            .GetAsync<CommonResponse<ServiceInfo>>(this.Url + RetrieveServiceInformation, cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Clients/Implementation/StatuslogClient.cs
+++ b/Omg.Lol.Net/Clients/Implementation/StatuslogClient.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Clients.Implementation;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Omg.Lol.Net.Clients.Abstract;
@@ -41,60 +42,88 @@ public sealed class StatuslogClient : IStatuslogClient
         this.apiServerCommunicationHandler = apiServerCommunicationHandler;
     }
 
-    public async Task<CommonResponse<SingleStatus>> RetrieveInvidualStatusAsync(string address, string statusId)
+    public async Task<CommonResponse<SingleStatus>> RetrieveInvidualStatusAsync(
+        string address,
+        string statusId,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<SingleStatus>>(
-                this.Url + string.Format(RetrieveIndividualStatusEndpoint, address, statusId))
+                this.Url + string.Format(RetrieveIndividualStatusEndpoint, address, statusId), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> DeleteStatusAsync(string address, string statusId)
+    public async Task<CommonResponse<MessageItem>> DeleteStatusAsync(
+        string address,
+        string statusId,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.DeleteAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(DeleteIndividualStatusEndpoint, address, statusId),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<SingleStatus>> RetrieveLatestStatusAsync(string address)
+    public async Task<CommonResponse<SingleStatus>> RetrieveLatestStatusAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<SingleStatus>>(
-                this.Url + string.Format(RetrieveLatestStatusEndpoint, address))
+                this.Url + string.Format(RetrieveLatestStatusEndpoint, address), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(string address)
+    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<MultipleStatuses>>(
-                this.Url + string.Format(RetrieveEntireStatusesEndpoint, address))
+                this.Url + string.Format(RetrieveEntireStatusesEndpoint, address), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync()
+    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireStatusesAsync(
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<MultipleStatuses>>(
-                this.Url + string.Format(RetrieveEveryoneStatusEndpoint))
+                this.Url + string.Format(RetrieveEveryoneStatusEndpoint), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireLatestStatusAsync()
+    public async Task<CommonResponse<MultipleStatuses>> RetrieveEntireLatestStatusAsync(
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<MultipleStatuses>>(
-                this.Url + string.Format(RetrieveEveryoneLatestStatusEndpoint))
+                this.Url + string.Format(RetrieveEveryoneLatestStatusEndpoint), cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<StatusModified>> CreateStatusAsync(string address, StatusPost status)
+    public async Task<CommonResponse<StatusModified>> CreateStatusAsync(
+        string address,
+        StatusPost status,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PostAsync<CommonResponse<StatusModified>>(
                 this.Url + string.Format(CreateStatusEndpoint, address),
                 JsonConvert.SerializeObject(status),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<StatusModified>> UpdateStatusAsync(string address, StatusPatch status)
+    public async Task<CommonResponse<StatusModified>> UpdateStatusAsync(
+        string address,
+        StatusPatch status,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PostAsync<CommonResponse<StatusModified>>(
                 this.Url + string.Format(UpdateStatusEndpoint, address),
                 JsonConvert.SerializeObject(status),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<StatusBio>> RetrieveStatusBioAsync(string address)
+    public async Task<CommonResponse<StatusBio>> RetrieveStatusBioAsync(
+        string address,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.GetAsync<CommonResponse<StatusBio>>(
-                this.Url + string.Format(RetrieveStatusBioEndpoint, address))
+                this.Url + string.Format(RetrieveStatusBioEndpoint, address),
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<CommonResponse<MessageItem>> UpdateStatusBioAsync(string address, ContentItem content)
+    public async Task<CommonResponse<MessageItem>> UpdateStatusBioAsync(
+        string address,
+        ContentItem content,
+        CancellationToken cancellationToken = default)
         => await this.apiServerCommunicationHandler.PostAsync<CommonResponse<MessageItem>>(
                 this.Url + string.Format(UpdateStatusBioEndpoint, address),
                 JsonConvert.SerializeObject(content),
-                this.Token)
+                this.Token,
+                cancellationToken)
             .ConfigureAwait(false);
 }

--- a/Omg.Lol.Net/Infrastructure/DefaultHttpClient.cs
+++ b/Omg.Lol.Net/Infrastructure/DefaultHttpClient.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 
 public class DefaultHttpClient : IHttpClient
@@ -17,35 +18,74 @@ public class DefaultHttpClient : IHttpClient
         return ret;
     });
 
-    public async Task<HttpResponseMessage> RequestAsync(HttpRequestMessage requestMessage)
-        => await HttpClient.Value.SendAsync(requestMessage).ConfigureAwait(false);
+    public async Task<HttpResponseMessage> RequestAsync(
+        HttpRequestMessage requestMessage,
+        CancellationToken cancellationToken = default)
+        => await HttpClient.Value.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
 
-    public async Task<HttpResponseMessage> GetAsync(string url)
-        => await this.SendInternalAsync(url, HttpMethod.Get).ConfigureAwait(false);
-
-    public async Task<HttpResponseMessage> GetAsync(string url, string bearerToken)
-        => await this.SendInternalAsync(url, HttpMethod.Get, bearerToken).ConfigureAwait(false);
-
-    public async Task<HttpResponseMessage> PostAsync(string url, string content, string bearerToken)
-        => await this.SendInternalAsync(url, HttpMethod.Post, bearerToken, new StringContent(content))
+    public async Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(url, HttpMethod.Get, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<HttpResponseMessage> PatchAsync(string url, string content, string bearerToken)
-        => await this.SendInternalAsync(url, new HttpMethod("PATCH"), bearerToken, new StringContent(content))
+    public async Task<HttpResponseMessage> GetAsync(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(url, HttpMethod.Get, bearerToken, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<HttpResponseMessage> PutAsync(string url, string content, string bearerToken)
-        => await this.SendInternalAsync(url, HttpMethod.Put, bearerToken, new StringContent(content))
+    public async Task<HttpResponseMessage> PostAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(
+                url,
+                HttpMethod.Post,
+                bearerToken,
+                new StringContent(content),
+                cancellationToken)
             .ConfigureAwait(false);
 
-    public async Task<HttpResponseMessage> DeleteAsync(string url, string bearerToken)
-        => await this.SendInternalAsync(url, HttpMethod.Delete, bearerToken).ConfigureAwait(false);
+    public async Task<HttpResponseMessage> PatchAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(
+                url,
+                new HttpMethod("PATCH"),
+                bearerToken,
+                new StringContent(content),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<HttpResponseMessage> PutAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(
+                url,
+                HttpMethod.Put,
+                bearerToken,
+                new StringContent(content),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<HttpResponseMessage> DeleteAsync(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default)
+        => await this.SendInternalAsync(url, HttpMethod.Delete, bearerToken, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
 
     private async Task<HttpResponseMessage> SendInternalAsync(
         string url,
         HttpMethod method,
         string? bearer = null,
-        HttpContent? content = null)
+        HttpContent? content = null,
+        CancellationToken cancellationToken = default)
     {
         var message = new HttpRequestMessage()
         {
@@ -60,6 +100,6 @@ public class DefaultHttpClient : IHttpClient
 
         message.Content = content;
 
-        return await this.RequestAsync(message).ConfigureAwait(false);
+        return await this.RequestAsync(message, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Omg.Lol.Net/Infrastructure/IApiKeyProvider.cs
+++ b/Omg.Lol.Net/Infrastructure/IApiKeyProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace Omg.Lol.Net.Infrastructure;
 
+using System.Threading;
 using System.Threading.Tasks;
 
 /// <summary>
@@ -10,5 +11,5 @@ using System.Threading.Tasks;
 /// </remarks>
 public interface IApiKeyProvider
 {
-    public Task<string> GetApiKeyAsync();
+    public Task<string> GetApiKeyAsync(CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Infrastructure/IApiServerCommunicationHandler.cs
+++ b/Omg.Lol.Net/Infrastructure/IApiServerCommunicationHandler.cs
@@ -1,18 +1,39 @@
 ﻿namespace Omg.Lol.Net.Infrastructure;
 
+using System.Threading;
 using System.Threading.Tasks;
 
 public interface IApiServerCommunicationHandler
 {
-    public Task<T> GetAsync<T>(string url, string bearerToken);
+    public Task<T> GetAsync<T>(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<T> GetAsync<T>(string url);
+    public Task<T> GetAsync<T>(
+        string url,
+        CancellationToken cancellationToken = default);
 
-    public Task<T> PostAsync<T>(string url, string content, string bearerToken);
+    public Task<T> PostAsync<T>(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<T> PatchAsync<T>(string url, string content, string bearerToken);
+    public Task<T> PatchAsync<T>(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<T> PutAsync<T>(string url, string content, string bearerToken);
+    public Task<T> PutAsync<T>(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<T> DeleteAsync<T>(string url, string bearerToken);
+    public Task<T> DeleteAsync<T>(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 }

--- a/Omg.Lol.Net/Infrastructure/IHttpClient.cs
+++ b/Omg.Lol.Net/Infrastructure/IHttpClient.cs
@@ -1,21 +1,42 @@
 ﻿namespace Omg.Lol.Net.Infrastructure;
 
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 public interface IHttpClient
 {
-    public Task<HttpResponseMessage> RequestAsync(HttpRequestMessage requestMessage);
+    public Task<HttpResponseMessage> RequestAsync(
+        HttpRequestMessage requestMessage,
+        CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> GetAsync(string url);
+    public Task<HttpResponseMessage> GetAsync(string url, CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> GetAsync(string url, string bearerToken);
+    public Task<HttpResponseMessage> GetAsync(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> PostAsync(string url, string content, string bearerToken);
+    public Task<HttpResponseMessage> PostAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> PatchAsync(string url, string content, string bearerToken);
+    public Task<HttpResponseMessage> PatchAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> PutAsync(string url, string content, string bearerToken);
+    public Task<HttpResponseMessage> PutAsync(
+        string url,
+        string content,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 
-    public Task<HttpResponseMessage> DeleteAsync(string url, string bearerToken);
+    public Task<HttpResponseMessage> DeleteAsync(
+        string url,
+        string bearerToken,
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
All async methods should have cancellation token passed down as best practice.