### PR TITLE
Build nupkg with symbol for easier decompiler inspection and drop to GitHub Release 

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -39,13 +39,17 @@ jobs:
         run: 'dotnet pack 
               -c Release 
               -o . 
+              -p:IncludeSymbols=true 
+              -p:SymbolPackageFormat=snupkg
               ./Omg.Lol.Net/Omg.Lol.Net.csproj'
 
       - name: Tag & Drop to Github Release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ github.event.inputs.pre-release }}
-          files: "*.nupkg"
+          files: |
+            "*.nupkg"
+            "*.snupkg"
           tag_name: v${{ steps.version-bump.outputs.newVersion }}
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.github/workflows/pr-baseline.yml
+++ b/.github/workflows/pr-baseline.yml
@@ -1,4 +1,4 @@
-name: Integration Test
+name: PR Baseline
 
 on: 
  workflow_dispatch:
@@ -10,7 +10,7 @@ jobs:
   Baseline:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2019, windows-2022, macos-12, macos-11]
+        os: [ubuntu-latest, windows-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install .NET SDK 7


### PR DESCRIPTION
- OS used is also reduced to 3 to save free minutes